### PR TITLE
Add Russian language

### DIFF
--- a/languages.yaml
+++ b/languages.yaml
@@ -1,3 +1,7 @@
 en:
   PLUGIN_DATABASE:
     DATABASE: Database
+    
+ru:
+  PLUGIN_DATABASE:
+    DATABASE: База данных


### PR DESCRIPTION
In blueprints, there is a text_var parameter which is not used anywhere. Is it laid for the future?