### PR TITLE
Fix PostgreSQL named connection DSNs

### DIFF
--- a/classes/Database.php
+++ b/classes/Database.php
@@ -60,7 +60,7 @@ class Database
                 $dsn .= ';password=' . $connection['password'];
                 $dsn .=
                     ';sslmode=' .
-                    \in_array($connection['sslmode'], [
+                    (\in_array($connection['sslmode'], [
                         'disable',
                         'allow',
                         'prefer',
@@ -69,7 +69,7 @@ class Database
                         'verify-full',
                     ])
                         ? $connection['sslmode']
-                        : 'prefer';
+                        : 'prefer');
                 $username = $connection['user'];
                 $password = $connection['password'];
                 break;
@@ -84,7 +84,7 @@ class Database
                 $dsn .= 'Server=' . $connection['server'];
                 $dsn .= ',' . $connection['port'];
                 $dsn .= ';Database=' . $connection['database'];
-                $dsn .= ';Encrypt=' . $connection['encrypt'] ? 'true' : 'false';
+                $dsn .= ';Encrypt=' . ($connection['encrypt'] ? 'true' : 'false');
                 $username = $connection['username'];
                 $password = $connection['password'];
                 break;

--- a/composer.json
+++ b/composer.json
@@ -12,5 +12,8 @@
     "platform": {
       "php": "7.1.3"
     }
+  },
+  "scripts": {
+    "test": "php tests/run.php"
   }
 }

--- a/tests/run.php
+++ b/tests/run.php
@@ -1,0 +1,74 @@
+<?php
+
+require_once __DIR__ . '/../classes/PDO.php';
+require_once __DIR__ . '/../classes/Database.php';
+
+use Grav\Plugin\Database\Database;
+
+final class CapturingDatabase extends Database
+{
+    public $connection;
+
+    public function __construct(array $connections)
+    {
+        $property = new ReflectionProperty(Database::class, 'connections');
+        $property->setValue($this, $connections);
+    }
+
+    public function connect($dsn, $username = '', $password = '', $options = [])
+    {
+        $this->connection = [
+            'dsn' => $dsn,
+            'username' => $username,
+            'password' => $password,
+            'options' => $options,
+        ];
+
+        return $this->connection;
+    }
+}
+
+function assertSameValue($expected, $actual, $message)
+{
+    if ($expected !== $actual) {
+        fwrite(STDERR, $message . PHP_EOL);
+        fwrite(STDERR, 'Expected: ' . var_export($expected, true) . PHP_EOL);
+        fwrite(STDERR, 'Actual: ' . var_export($actual, true) . PHP_EOL);
+        exit(1);
+    }
+}
+
+function testPgsqlNamedConnectionBuildsDsn()
+{
+    if (!in_array('pgsql', PDO::getAvailableDrivers(), true)) {
+        fwrite(STDOUT, "Skipped PostgreSQL DSN test because pdo_pgsql is unavailable\n");
+        return;
+    }
+
+    $database = new CapturingDatabase([
+        'pgsql' => [
+            [
+                'name' => 'page_views',
+                'host' => 'db.example.test',
+                'port' => 5432,
+                'dbname' => 'grav',
+                'user' => 'grav',
+                'password' => 'secret',
+                'sslmode' => 'require',
+            ],
+        ],
+    ]);
+
+    $database->pgsql('page_views');
+
+    assertSameValue(
+        'pgsql:host=db.example.test;port=5432;dbname=grav;user=grav;password=secret;sslmode=require',
+        $database->connection['dsn'],
+        'PostgreSQL named connections should preserve the sslmode DSN key.'
+    );
+    assertSameValue('grav', $database->connection['username'], 'PostgreSQL username should be passed to PDO.');
+    assertSameValue('secret', $database->connection['password'], 'PostgreSQL password should be passed to PDO.');
+}
+
+testPgsqlNamedConnectionBuildsDsn();
+fwrite(STDOUT, "All database plugin tests passed\n");


### PR DESCRIPTION
## Summary
- Preserve the `;sslmode=` key when building named PostgreSQL DSNs.
- Correct the same ternary precedence issue for SQL Server `Encrypt` DSN values.
- Add a focused test runner covering PostgreSQL named connection DSN generation.

## Test Plan
- `php tests/run.php`
- `php -l classes/Database.php`
- `php -l tests/run.php`

Note: `composer validate --strict` still reports existing package metadata gaps (`name`, `description`, and `license`) unrelated to this change.